### PR TITLE
Fix/bitnami with postgresql official image

### DIFF
--- a/charts/anything-llm/templates/sso-configmap.yaml
+++ b/charts/anything-llm/templates/sso-configmap.yaml
@@ -8,13 +8,18 @@ metadata:
     app.kubernetes.io/component: sso
 data:
   POSTGRES_HOST: {{ printf "%s-postgresql" .Release.Name | quote }}
+  POSTGRES_PORT: {{ .Values.sso.config.POSTGRES_PORT | default "5432" | quote }}
   POSTGRES_USER: {{ .Values.sso.config.POSTGRES_USER | quote }}
   POSTGRES_DB: {{ .Values.sso.config.POSTGRES_DB | quote }}
   KEYCLOAK_ANYTHING_LLM_ID_CLAIM: {{ .Values.sso.config.KEYCLOAK_ANYTHING_LLM_ID_CLAIM | quote }}
   KEYCLOAK_ANYTHING_LLM_USERNAME_CLAIM: {{ .Values.sso.config.KEYCLOAK_ANYTHING_LLM_USERNAME_CLAIM | quote }}
   KEYCLOAK_ANYTHING_LLM_GROUP_CLAIM: {{ .Values.sso.config.KEYCLOAK_ANYTHING_LLM_GROUP_CLAIM | quote }}
   KEYCLOAK_ANYTHING_LLM_GROUP_CORRELATIONS: {{ .Values.sso.config.KEYCLOAK_ANYTHING_LLM_GROUP_CORRELATIONS | quote }}
+  {{- if .Values.sso.config.ANYTHING_LLM_URL }}
   ANYTHING_LLM_URL: {{ .Values.sso.config.ANYTHING_LLM_URL | quote }}
+  {{- else }}
+  ANYTHING_LLM_URL: {{ printf "http://%s:%d" (include "anything-llm.fullname" .) (.Values.service.port | int) | quote }}
+  {{- end }}
   ANYTHING_LLM_ADMIN_USER: {{ .Values.sso.config.ANYTHING_LLM_ADMIN_USER | quote }}
   ANYTHING_LLM_VERIFY_SSL: {{ .Values.sso.config.ANYTHING_LLM_VERIFY_SSL | quote }}
 {{- end }} 

--- a/charts/anything-llm/templates/sso-deployment.yaml
+++ b/charts/anything-llm/templates/sso-deployment.yaml
@@ -66,12 +66,16 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /monitoring/health
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.sso.resources | nindent 12 }}
       {{- with .Values.sso.nodeSelector }}

--- a/charts/anything-llm/values-sso-test.yaml
+++ b/charts/anything-llm/values-sso-test.yaml
@@ -47,7 +47,7 @@ sso:
     KEYCLOAK_ANYTHING_LLM_GROUP_CLAIM: "groups"
     KEYCLOAK_ANYTHING_LLM_GROUP_CORRELATIONS: "anything_llm_manager;manager,anything_llm_default;default,anything_llm_admin;admin"
     # AnythingLLM API configuration
-    ANYTHING_LLM_URL: "https://llm.example.com"
+    ANYTHING_LLM_URL: ""
     ANYTHING_LLM_ADMIN_USER: "admin"
     ANYTHING_LLM_ADMIN_PASSWORD: "administrador"
     ANYTHING_LLM_VERIFY_SSL: "false"

--- a/charts/anything-llm/values-sso-test.yaml
+++ b/charts/anything-llm/values-sso-test.yaml
@@ -80,6 +80,14 @@ sso:
         enabled: true
         size: 8Gi
         storageClass: ""
+      # -- Extra volumes for official PostgreSQL image compatibility
+      # Mount emptyDir for /var/run/postgresql to fix read-only filesystem issue
+      extraVolumes:
+        - name: postgresql-run
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: postgresql-run
+          mountPath: /var/run/postgresql
 
     # PostgreSQL resources
     resources:
@@ -92,10 +100,12 @@ sso:
     # PostgreSQL architecture
     architecture: standalone
     # PostgreSQL image configuration
+    # Using official PostgreSQL image instead of Bitnami due to licensing changes
+    # Note: The official PostgreSQL image uses different env var names than Bitnami
     image:
       registry: docker.io
-      repository: bitnami/postgresql
-      tag: "16.2.0"
+      repository: postgres
+      tag: "16"
     # PostgreSQL metrics
     metrics:
       enabled: false 

--- a/charts/anything-llm/values-test.yaml
+++ b/charts/anything-llm/values-test.yaml
@@ -107,6 +107,14 @@ postgresql:
       enabled: true
       size: 8Gi
       storageClass: ""
+    # -- Extra volumes for official PostgreSQL image compatibility
+    # Mount emptyDir for /var/run/postgresql to fix read-only filesystem issue
+    extraVolumes:
+      - name: postgresql-run
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: postgresql-run
+        mountPath: /var/run/postgresql
     # PostgreSQL resources
     resources:
       limits:
@@ -118,10 +126,12 @@ postgresql:
   # PostgreSQL architecture
   architecture: standalone
   # PostgreSQL image configuration
+  # Using official PostgreSQL image instead of Bitnami due to licensing changes
+  # Note: The official PostgreSQL image uses different env var names than Bitnami
   image:
     registry: docker.io
-    repository: bitnami/postgresql
-    tag: "16.2.0"
+    repository: postgres
+    tag: "16"
   # PostgreSQL metrics
   metrics:
     enabled: false

--- a/charts/anything-llm/values-test.yaml
+++ b/charts/anything-llm/values-test.yaml
@@ -68,7 +68,7 @@ sso:
     KEYCLOAK_ANYTHING_LLM_GROUP_CLAIM: "groups"
     KEYCLOAK_ANYTHING_LLM_GROUP_CORRELATIONS: "anything_llm_manager;manager,anything_llm_default;default,anything_llm_admin;admin"
     # AnythingLLM API configuration
-    ANYTHING_LLM_URL: "https://llm.example.com"
+    ANYTHING_LLM_URL: ""
     ANYTHING_LLM_ADMIN_USER: "admin"
     ANYTHING_LLM_ADMIN_PASSWORD: "administrador"
     ANYTHING_LLM_VERIFY_SSL: "false"

--- a/charts/anything-llm/values.yaml
+++ b/charts/anything-llm/values.yaml
@@ -213,6 +213,7 @@ sso:
   config:
     # -- PostgreSQL configuration
     POSTGRES_HOST: "postgresql"
+    POSTGRES_PORT: "5432"
     POSTGRES_USER: "postgres"
     POSTGRES_PASSWORD: "sso-anythingllm123"
     POSTGRES_DB: "sso_anythingllm"
@@ -222,7 +223,10 @@ sso:
     KEYCLOAK_ANYTHING_LLM_GROUP_CLAIM: "groups"
     KEYCLOAK_ANYTHING_LLM_GROUP_CORRELATIONS: "anything_llm_manager;manager,anything_llm_default;default,anything_llm_admin;admin"
     # -- AnythingLLM API configuration
-    ANYTHING_LLM_URL: "https://llm.example.com"
+    # If not set, will default to internal service URL: http://<service-name>:<service-port>
+    # For internal cluster communication, leave empty to use service name
+    # For external access via ingress, set to: "https://llm.example.com"
+    ANYTHING_LLM_URL: ""  # Empty = use internal service (http://anything-llm:3001)
     ANYTHING_LLM_ADMIN_USER: "admin"
     ANYTHING_LLM_ADMIN_PASSWORD: "administrador"
     ANYTHING_LLM_VERIFY_SSL: "false"

--- a/charts/anything-llm/values.yaml
+++ b/charts/anything-llm/values.yaml
@@ -271,8 +271,14 @@ sso:
         enabled: true
         size: 8Gi
         storageClass: ""
-
-
+      # -- Extra volumes for official PostgreSQL image compatibility
+      # Mount emptyDir for /var/run/postgresql to fix read-only filesystem issue
+      extraVolumes:
+        - name: postgresql-run
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: postgresql-run
+          mountPath: /var/run/postgresql
 
     # -- PostgreSQL resources
     resources:
@@ -285,10 +291,15 @@ sso:
     # -- PostgreSQL architecture
     architecture: standalone
     # -- PostgreSQL image configuration
+    # Using official PostgreSQL image instead of Bitnami due to licensing changes
+    # The official PostgreSQL image (postgres:16) uses standard env vars:
+    # POSTGRES_PASSWORD, POSTGRES_DB, POSTGRES_USER
+    # Note: The Bitnami chart may need extraEnvVars to map auth values correctly
+    # If authentication fails, you may need to add extraEnvVars mapping
     image:
       registry: docker.io
-      repository: bitnami/postgresql
-      tag: "16.2.0"
+      repository: postgres
+      tag: "16"
     # -- PostgreSQL metrics
     metrics:
       enabled: false


### PR DESCRIPTION
Cambios ejecutados:
- Adaptación de los values.yaml para especificar la imagen oficial de PostgreSQL en lugar de la imagen procedente del repositorio de Bitnami (imagen por defecto utilizada por el chart).
- Gestión adicional de configuración para PostgreSQL dada la divergencia entre los prefijos de varaibles de entorno utilizados por defecto por el chart y la imagen (la imagen de Bitnami acepta diferentes prefijos que la imagen oficial).
- Mejora de facilidad de despliegue asignando por defecto el nombre de servicio para comunicación contra AnythingLLm desde el servicio de SSO, en caso de que no se especifique la URL de Anything LLM (se asume despliegue local en el mismo cluster).